### PR TITLE
feat: add world generation and team selection

### DIFF
--- a/src/ServerScriptService/Teams.server.lua
+++ b/src/ServerScriptService/Teams.server.lua
@@ -1,0 +1,55 @@
+-- Teams.server.lua
+-- Knights vs Barbarians selection + spawning
+
+local Players = game:GetService("Players")
+local TeamsService = game:GetService("Teams")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+-- Teams
+local Knights = TeamsService:FindFirstChild("Knights") or Instance.new("Team")
+Knights.Name = "Knights"; Knights.TeamColor = BrickColor.new("Bright blue"); Knights.AutoAssignable = false; Knights.Parent = TeamsService
+
+local Barbarians = TeamsService:FindFirstChild("Barbarians") or Instance.new("Team")
+Barbarians.Name = "Barbarians"; Barbarians.TeamColor = BrickColor.new("Bright red"); Barbarians.AutoAssignable = false; Barbarians.Parent = TeamsService
+
+-- Remote to choose team
+local Remotes = ReplicatedStorage:FindFirstChild("AdventureRemotes") or Instance.new("Folder")
+Remotes.Name = "AdventureRemotes"; Remotes.Parent = ReplicatedStorage
+local ChooseTeam = Remotes:FindFirstChild("ChooseTeam") or Instance.new("RemoteEvent")
+ChooseTeam.Name = "ChooseTeam"; ChooseTeam.Parent = Remotes
+
+-- Locate spawns (from WorldGen)
+local function getSpawnForTeam(team: Team)
+local spawn
+if team == Knights then
+spawn = workspace:FindFirstChild("World") and workspace.World:FindFirstChild("Castle") and workspace.World.Castle:FindFirstChild("KnightSpawn")
+elseif team == Barbarians then
+spawn = workspace:FindFirstChild("World") and workspace.World:FindFirstChild("BarbarianCamp") and workspace.World.BarbarianCamp:FindFirstChild("BarbarianSpawn")
+end
+return spawn
+end
+
+ChooseTeam.OnServerEvent:Connect(function(plr, which: string)
+local target = (which == "Knights") and Knights or Barbarians
+plr.Team = target
+-- move them to their spawn if alive
+if plr.Character and plr.Character:FindFirstChild("HumanoidRootPart") then
+local sp = getSpawnForTeam(target)
+if sp then
+plr.Character.HumanoidRootPart.CFrame = CFrame.new(sp.Position + Vector3.new(0, 5, 0))
+end
+end
+end)
+
+-- When a player spawns after choosing team, keep them near their base
+Players.PlayerAdded:Connect(function(plr)
+plr.CharacterAdded:Connect(function(char)
+task.wait(0.2)
+if plr.Team then
+local sp = getSpawnForTeam(plr.Team)
+if sp and char:FindFirstChild("HumanoidRootPart") then
+char.HumanoidRootPart.CFrame = CFrame.new(sp.Position + Vector3.new(0, 5, 0))
+end
+end
+end)
+end)

--- a/src/ServerScriptService/WorldGen.server.lua
+++ b/src/ServerScriptService/WorldGen.server.lua
@@ -1,0 +1,87 @@
+-- WorldGen.server.lua
+-- Drops a quick playable world: forest, mountains, a castle (Knights) and a camp (Barbarians)
+
+local World = workspace:FindFirstChild("World") or Instance.new("Folder")
+World.Name = "World"; World.Parent = workspace
+
+local function mkPart(name, size, cframe, color, material, anchored, parent)
+local p = Instance.new("Part")
+p.Name = name
+p.Size = size
+p.CFrame = cframe
+p.Color = color or Color3.fromRGB(120,120,120)
+p.Material = material or Enum.Material.Slate
+p.Anchored = anchored ~= false
+p.TopSurface = Enum.SurfaceType.Smooth
+p.BottomSurface = Enum.SurfaceType.Smooth
+p.Parent = parent or World
+return p
+end
+
+-- Flat base so coins/NPCs don’t fall
+local base = mkPart("Ground", Vector3.new(500, 2, 500), CFrame.new(0, 0, 0), Color3.fromRGB(58, 125, 21), Enum.Material.Grass)
+base.Locked = true
+
+-- Forest
+local Forest = Instance.new("Folder"); Forest.Name = "Forest"; Forest.Parent = World
+local function mkTree(pos: Vector3)
+local trunk = mkPart("Trunk", Vector3.new(2, 12, 2), CFrame.new(pos + Vector3.new(0,6,0)), Color3.fromRGB(101,67,33), Enum.Material.Wood)
+trunk.Shape = Enum.PartType.Cylinder; trunk.Orientation = Vector3.new(0,0,90)
+local leaves = Instance.new("Part")
+leaves.Name="Leaves"; leaves.Size=Vector3.new(8,6,8); leaves.Shape=Enum.PartType.Ball
+leaves.Color = Color3.fromRGB(41, 121, 41); leaves.Material = Enum.Material.Grass; leaves.Anchored = true
+leaves.CFrame = CFrame.new(pos + Vector3.new(0,14,0)); leaves.Parent = Forest
+trunk.Parent = Forest
+end
+math.randomseed(os.time())
+for i=1,45 do
+local x = math.random(-200, -40)
+local z = math.random(-200, 200)
+mkTree(Vector3.new(x, 1, z))
+end
+
+-- Mountains (simple rock piles)
+local Mountains = Instance.new("Folder"); Mountains.Name = "Mountains"; Mountains.Parent = World
+for i=1,14 do
+local x = math.random(60, 220)
+local z = math.random(-220, 220)
+local height = math.random(20, 50)
+local steps = math.random(3,6)
+for s=1,steps do
+local size = Vector3.new(math.max(14 - s*2, 6), height/steps, math.max(14 - s*2, 6))
+local y = (height/steps)*s
+mkPart("RockStep", size, CFrame.new(x + math.random(-4,4), y, z + math.random(-4,4)), Color3.fromRGB(110,110,110), Enum.Material.Rock, true, Mountains)
+end
+end
+
+-- Knight castle (very blocky but fast)
+local Castle = Instance.new("Folder"); Castle.Name = "Castle"; Castle.Parent = World
+local castleCenter = Vector3.new(120, 1, 0)
+-- walls
+mkPart("WallN", Vector3.new(80, 18, 4), CFrame.new(castleCenter + Vector3.new(0, 9, -40)), Color3.fromRGB(150,150,150), Enum.Material.Concrete, true, Castle)
+mkPart("WallS", Vector3.new(80, 18, 4), CFrame.new(castleCenter + Vector3.new(0, 9,  40)), Color3.fromRGB(150,150,150), Enum.Material.Concrete, true, Castle)
+mkPart("WallE", Vector3.new(4, 18, 80), CFrame.new(castleCenter + Vector3.new(40, 9, 0)),  Color3.fromRGB(150,150,150), Enum.Material.Concrete, true, Castle)
+mkPart("WallW", Vector3.new(4, 18, 80), CFrame.new(castleCenter + Vector3.new(-40, 9, 0)), Color3.fromRGB(150,150,150), Enum.Material.Concrete, true, Castle)
+-- keep
+mkPart("Keep", Vector3.new(20, 24, 20), CFrame.new(castleCenter + Vector3.new(0, 12, 0)), Color3.fromRGB(170,170,170), Enum.Material.Concrete, true, Castle)
+-- knight spawn
+local knightSpawn = Instance.new("SpawnLocation")
+knightSpawn.Name = "KnightSpawn"; knightSpawn.Position = castleCenter + Vector3.new(-10, 6, 0)
+knightSpawn.Size = Vector3.new(6,1,6); knightSpawn.Anchored = true; knightSpawn.Neutral = false
+knightSpawn.BrickColor = BrickColor.new("Bright blue"); knightSpawn.Parent = Castle
+
+-- Barbarian camp
+local Camp = Instance.new("Folder"); Camp.Name = "BarbarianCamp"; Camp.Parent = World
+local campCenter = Vector3.new(-120, 1, 0)
+-- totems / tents
+for i=1,5 do
+local offset = Vector3.new(i*6 - 15, 0, math.random(-10,10))
+mkPart("Totem"..i, Vector3.new(2, 10, 2), CFrame.new(campCenter + offset + Vector3.new(0,5,0)), Color3.fromRGB(139,69,19), Enum.Material.Wood, true, Camp)
+end
+-- campfire
+local fireBase = mkPart("CampFire", Vector3.new(6,1,6), CFrame.new(campCenter + Vector3.new(0,1,0)), Color3.fromRGB(90,50,30), Enum.Material.Wood, true, Camp)
+-- barbarian spawn
+local barbSpawn = Instance.new("SpawnLocation")
+barbSpawn.Name = "BarbarianSpawn"; barbSpawn.Position = campCenter + Vector3.new(10, 6, 0)
+barbSpawn.Size = Vector3.new(6,1,6); barbSpawn.Anchored = true; barbSpawn.Neutral = false
+barbSpawn.BrickColor = BrickColor.new("Bright red"); barbSpawn.Parent = Camp

--- a/src/StarterPlayer/StarterPlayerScripts/TeamSelect.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/TeamSelect.client.lua
@@ -1,0 +1,36 @@
+-- TeamSelect.client.lua
+-- Minimal team selection UI that talks to Teams.server.lua
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Players = game:GetService("Players")
+local Remotes = ReplicatedStorage:WaitForChild("AdventureRemotes")
+local ChooseTeam = Remotes:WaitForChild("ChooseTeam")
+
+local player = Players.LocalPlayer
+local gui = Instance.new("ScreenGui"); gui.Name = "TeamPicker"; gui.ResetOnSpawn = false; gui.Parent = player:WaitForChild("PlayerGui")
+
+local frame = Instance.new("Frame"); frame.Size = UDim2.fromOffset(360, 140); frame.Position = UDim2.new(0.5, -180, 0.5, -70)
+frame.BackgroundColor3 = Color3.fromRGB(25,25,30); frame.Parent = gui
+local corner = Instance.new("UICorner"); corner.CornerRadius = UDim.new(0,10); corner.Parent = frame
+
+local title = Instance.new("TextLabel"); title.Size = UDim2.fromOffset(340, 30); title.Position = UDim2.fromOffset(10, 10)
+title.BackgroundTransparency = 1; title.TextColor3 = Color3.fromRGB(240,240,255); title.Font = Enum.Font.GothamBold; title.TextSize = 20
+title.Text = "Choose your side"; title.Parent = frame
+
+local knights = Instance.new("TextButton"); knights.Size = UDim2.fromOffset(150, 50); knights.Position = UDim2.fromOffset(20, 70)
+knights.Text = "Join Knights"; knights.BackgroundColor3 = BrickColor.new("Bright blue").Color
+local knCorner = Instance.new("UICorner"); knCorner.CornerRadius = UDim.new(0,8); knCorner.Parent = knights
+knights.Parent = frame
+
+local barbs = Instance.new("TextButton"); barbs.Size = UDim2.fromOffset(150, 50); barbs.Position = UDim2.fromOffset(190, 70)
+barbs.Text = "Join Barbarians"; barbs.BackgroundColor3 = BrickColor.new("Bright red").Color
+local bbCorner = Instance.new("UICorner"); bbCorner.CornerRadius = UDim.new(0,8); bbCorner.Parent = barbs
+barbs.Parent = frame
+
+local function choose(which)
+ChooseTeam:FireServer(which)
+gui.Enabled = false -- dismiss after pick
+end
+
+knights.MouseButton1Click:Connect(function() choose("Knights") end)
+barbs.MouseButton1Click:Connect(function() choose("Barbarians") end)


### PR DESCRIPTION
## Summary
- generate world with forest, mountains, castle, and barbarian camp
- add server-side team logic and spawn handling
- add client team selection UI

## Testing
- `rojo build default.project.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf3170288832bb3b5ad015e1a64f3