### PR TITLE
feat: add siege rewrite skeleton

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -2,9 +2,15 @@
   "name": "AdventureGame",
   "tree": {
     "$className": "DataModel",
-    "ReplicatedStorage": {},
+    "ReplicatedStorage": {
+      "Remotes": {"$path": "src/ReplicatedStorage/Remotes"},
+      "Modules": {"$path": "src/ReplicatedStorage/Modules"}
+    },
     "ServerScriptService": {
       "$path": "src/ServerScriptService"
+    },
+    "ServerStorage": {
+      "Prefabs": {"$path": "src/ServerStorage/Prefabs"}
     },
     "StarterPlayer": {
       "StarterPlayerScripts": {

--- a/src/ReplicatedStorage/Modules/Config.lua
+++ b/src/ReplicatedStorage/Modules/Config.lua
@@ -1,0 +1,26 @@
+local Config = {}
+
+Config.FACTIONS = {"Attacker","Defender"}
+
+Config.NPC_SCALING = { BASE_NPC=20, P_REF=2, MIN_NPC=6, MAX_NPC=22 }
+
+Config.START_RESOURCES = { Coins=250, Wood=200, Stone=120, Iron=60, Coal=30, Food=120 }
+
+Config.BUILD_COSTS = {
+  Farm={Wood=40, Coins=20},
+  Mine={Wood=30, Stone=10, Coins=20},
+  Blacksmith={Wood=40, Stone=40, Iron=10, Coins=40},
+  House={Wood=30, Stone=10},
+  Granary={Wood=20, Stone=30},
+  Market={Wood=50, Stone=30, Coins=60},
+  Dock={Wood=60, Stone=20, Coins=50},
+  Wall={Stone=20},
+  Tower={Stone=50, Iron=5, Coins=25},
+  Cannon={Iron=30, Coal=20, Stone=40, Coins=120},
+}
+
+Config.JOB_PRIORITIES = { RepairWall=100, BuildDefense=95, DeliverSiege=90, BuildCoreEcon=80, HaulGoods=60, Farm=50, Mine=50, Smithing=50, TradeRun=45 }
+
+Config.Flags = { NewMatchmaker=true, NewEconomy=true, NewNPCs=true }
+
+return Config

--- a/src/ReplicatedStorage/Modules/Economy.lua
+++ b/src/ReplicatedStorage/Modules/Economy.lua
@@ -1,0 +1,45 @@
+local Economy = {}
+
+function Economy.HasResources(res, cost)
+    for k,v in pairs(cost) do
+        if (res[k] or 0) < v then
+            return false
+        end
+    end
+    return true
+end
+
+function Economy.Pay(res, cost)
+    for k,v in pairs(cost) do
+        res[k] = (res[k] or 0) - v
+    end
+end
+
+function Economy.Add(res, delta)
+    for k,v in pairs(delta) do
+        res[k] = (res[k] or 0) + v
+    end
+end
+
+function Economy.TickPopulation(state)
+    local pop = state.Population or 0
+    local upkeep = pop
+    state.Resources.Food = (state.Resources.Food or 0) - upkeep
+    local tax = math.floor(pop/2)
+    state.Resources.Coins = (state.Resources.Coins or 0) + tax
+end
+
+function Economy.ApplyTradeRoutes(state)
+    -- placeholder for future trade logic
+end
+
+function Economy.UnlockTech(state, tech)
+    if tech == "GunpowderAge" then
+        if state.Tech.GunpowderAge then return end
+        if state.Built and state.Built.Blacksmith and state.Built.Market and state.Built.Dock then
+            state.Tech.GunpowderAge = true
+        end
+    end
+end
+
+return Economy

--- a/src/ReplicatedStorage/Modules/FactionState.lua
+++ b/src/ReplicatedStorage/Modules/FactionState.lua
@@ -1,0 +1,31 @@
+local Config = require(script.Parent.Config)
+local JobQueue = require(script.Parent.JobQueue)
+
+local states = {}
+
+local FactionState = {}
+
+local function cloneTable(t)
+    local c = {}
+    for k,v in pairs(t) do c[k]=v end
+    return c
+end
+
+local function init(name)
+    local st = {
+        Players = {},
+        NPCs = {},
+        Resources = cloneTable(Config.START_RESOURCES),
+        JobQueue = JobQueue.new(),
+        Tech = {GunpowderAge=false},
+        Population = 0,
+    }
+    states[name] = st
+    return st
+end
+
+function FactionState.Get(name)
+    return states[name] or init(name)
+end
+
+return FactionState

--- a/src/ReplicatedStorage/Modules/JobQueue.lua
+++ b/src/ReplicatedStorage/Modules/JobQueue.lua
@@ -1,0 +1,19 @@
+local JobQueue = {}
+JobQueue.__index = JobQueue
+
+function JobQueue.new()
+    return setmetatable({items={}}, JobQueue)
+end
+
+function JobQueue:push(job)
+    table.insert(self.items, job)
+    table.sort(self.items, function(a,b)
+        return (a.priority or 0) > (b.priority or 0)
+    end)
+end
+
+function JobQueue:pop()
+    return table.remove(self.items, 1)
+end
+
+return JobQueue

--- a/src/ReplicatedStorage/Modules/NPCBrain.lua
+++ b/src/ReplicatedStorage/Modules/NPCBrain.lua
@@ -1,0 +1,44 @@
+local FactionState = require(script.Parent.FactionState)
+local Pathing = require(script.Parent.Pathing)
+
+local NPCBrain = {}
+
+local handlers = {}
+
+function handlers.Build(npc, job, faction)
+    local ServerStorage = game:GetService("ServerStorage")
+    local prefabFolder = ServerStorage:FindFirstChild("Prefabs")
+    if not prefabFolder then return end
+    local model = prefabFolder:FindFirstChild("Buildings")
+    model = model and model:FindFirstChild(job.prefab)
+    if model then
+        local clone = model:Clone()
+        clone:SetPrimaryPartCFrame(CFrame.new(job.position))
+        clone.Parent = workspace
+    end
+end
+
+function NPCBrain.Init(npc, faction)
+    local state = FactionState.Get(faction)
+    npc:SetAttribute("Busy", false)
+    task.spawn(function()
+        while npc.Parent do
+            local job = state.JobQueue:pop()
+            if job then
+                npc:SetAttribute("Busy", true)
+                if job.position and npc.PrimaryPart then
+                    Pathing.GoTo(npc, job.position)
+                end
+                local handler = handlers[job.type]
+                if handler then
+                    handler(npc, job, faction)
+                end
+                npc:SetAttribute("Busy", false)
+            else
+                task.wait(1)
+            end
+        end
+    end)
+end
+
+return NPCBrain

--- a/src/ReplicatedStorage/Modules/Pathing.lua
+++ b/src/ReplicatedStorage/Modules/Pathing.lua
@@ -1,0 +1,15 @@
+local Pathing = {}
+
+function Pathing.GoTo(model, position)
+    if not (model and model.PrimaryPart) then return end
+    model:MoveTo(position)
+    local reached = Instance.new("BindableEvent")
+    local conn
+    conn = model.MoveToFinished:Connect(function(reachedGoal)
+        if conn then conn:Disconnect() end
+        reached:Fire(reachedGoal)
+    end)
+    reached.Event:Wait()
+end
+
+return Pathing

--- a/src/ReplicatedStorage/Remotes/AssignJob.meta.json
+++ b/src/ReplicatedStorage/Remotes/AssignJob.meta.json
@@ -1,0 +1,1 @@
+{ "className": "RemoteEvent" }

--- a/src/ReplicatedStorage/Remotes/LobbyStatus.meta.json
+++ b/src/ReplicatedStorage/Remotes/LobbyStatus.meta.json
@@ -1,0 +1,1 @@
+{ "className": "RemoteEvent" }

--- a/src/ReplicatedStorage/Remotes/RequestBuild.meta.json
+++ b/src/ReplicatedStorage/Remotes/RequestBuild.meta.json
@@ -1,0 +1,1 @@
+{ "className": "RemoteEvent" }

--- a/src/ReplicatedStorage/Remotes/StatePush.meta.json
+++ b/src/ReplicatedStorage/Remotes/StatePush.meta.json
@@ -1,0 +1,1 @@
+{ "className": "RemoteEvent" }

--- a/src/ServerScriptService/BuildService.server.lua
+++ b/src/ServerScriptService/BuildService.server.lua
@@ -1,0 +1,33 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RequestBuild = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("RequestBuild")
+
+local Config = require(ReplicatedStorage.Modules.Config)
+local FactionState = require(ReplicatedStorage.Modules.FactionState)
+local Economy = require(ReplicatedStorage.Modules.Economy)
+
+local function teamNameOf(player)
+    return player.Team and player.Team.Name
+end
+
+RequestBuild.OnServerEvent:Connect(function(player, buildingName, position)
+    if not Config.Flags.NewNPCs then return end
+    local tname = teamNameOf(player); if not tname then return end
+    if not Config.BUILD_COSTS[buildingName] then return end
+
+    local st = FactionState.Get(tname)
+    local cost = Config.BUILD_COSTS[buildingName]
+
+    if buildingName == "Cannon" and not (st.Tech and st.Tech.GunpowderAge) then
+        return
+    end
+
+    if Economy.HasResources(st.Resources, cost) then
+        Economy.Pay(st.Resources, cost)
+        st.JobQueue:push({
+            type = "Build", prefab = buildingName, position = position,
+            priority = Config.JOB_PRIORITIES.BuildCoreEcon
+        })
+        st.Built = st.Built or {}
+        st.Built[buildingName] = true
+    end
+end)

--- a/src/ServerScriptService/EconomyService.server.lua
+++ b/src/ServerScriptService/EconomyService.server.lua
@@ -1,0 +1,27 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+
+local Config = require(ReplicatedStorage.Modules.Config)
+local FactionState = require(ReplicatedStorage.Modules.FactionState)
+local Economy = require(ReplicatedStorage.Modules.Economy)
+
+local StatePush = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("StatePush")
+
+local function tickFaction(name)
+    local state = FactionState.Get(name)
+    Economy.TickPopulation(state)
+    Economy.ApplyTradeRoutes(state)
+    Economy.UnlockTech(state, "GunpowderAge")
+    StatePush:FireAllClients(name, {
+        resources = state.Resources,
+        pop = state.Population,
+        tech = state.Tech,
+    })
+end
+
+while true do
+    task.wait(5)
+    for _, f in ipairs(Config.FACTIONS) do
+        tickFaction(f)
+    end
+end

--- a/src/ServerScriptService/Matchmaker.server.lua
+++ b/src/ServerScriptService/Matchmaker.server.lua
@@ -1,0 +1,69 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Teams = game:GetService("Teams")
+
+local LobbyStatus = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("LobbyStatus")
+local Config = require(ReplicatedStorage.Modules.Config)
+
+local teams = { Attacker = {}, Defender = {} }
+local waitingQueue = {}
+
+local function total()
+    return #teams.Attacker + #teams.Defender
+end
+
+local function inTable(t, p)
+    for i, x in ipairs(t) do
+        if x == p then return i end
+    end
+    return nil
+end
+
+local function assignTeam(player)
+    if #teams.Attacker <= #teams.Defender then
+        table.insert(teams.Attacker, player)
+        player.Team = Teams:WaitForChild("Attacker")
+    else
+        table.insert(teams.Defender, player)
+        player.Team = Teams:WaitForChild("Defender")
+    end
+end
+
+local function removePlayer(player)
+    for _, list in pairs(teams) do
+        local idx = inTable(list, player)
+        if idx then table.remove(list, idx) end
+    end
+    local q = inTable(waitingQueue, player)
+    if q then table.remove(waitingQueue, q) end
+end
+
+local function broadcast()
+    LobbyStatus:FireAllClients({
+        attackers = #teams.Attacker,
+        defenders = #teams.Defender,
+        total = total(),
+        evenReady = (total() % 2 == 0 and total() >= 2)
+    })
+end
+
+Players.PlayerAdded:Connect(function(player)
+    if (total() % 2) == 1 then
+        table.insert(waitingQueue, player)
+        player.Team = Teams:WaitForChild("Spectator")
+    else
+        assignTeam(player)
+    end
+    broadcast()
+end)
+
+Players.PlayerRemoving:Connect(function(player)
+    removePlayer(player)
+    if (total() % 2) == 1 and #waitingQueue > 0 then
+        local promote = table.remove(waitingQueue, 1)
+        assignTeam(promote)
+    end
+    broadcast()
+end)
+
+return teams

--- a/src/ServerScriptService/NPCService.server.lua
+++ b/src/ServerScriptService/NPCService.server.lua
@@ -1,0 +1,45 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ServerStorage = game:GetService("ServerStorage")
+local RunService = game:GetService("RunService")
+
+local Config = require(ReplicatedStorage.Modules.Config)
+local FactionState = require(ReplicatedStorage.Modules.FactionState)
+local NPCBrain = require(ReplicatedStorage.Modules.NPCBrain)
+
+local WorkerPrefab = ServerStorage:WaitForChild("Prefabs"):WaitForChild("Units"):WaitForChild("WorkerNPC", 0)
+
+local function clamp(n,a,b) return math.max(a, math.min(b,n)) end
+
+local function budget(players)
+    local s = Config.NPC_SCALING
+    local p = math.max(1, players)
+    return clamp(math.ceil(s.BASE_NPC*(s.P_REF/p)), s.MIN_NPC, s.MAX_NPC)
+end
+
+local function ensureNPCs(faction)
+    local st = FactionState.Get(faction)
+    local want = budget(#st.Players)
+    local have = #st.NPCs
+
+    if have < want then
+        for _ = 1,(want-have) do
+            if WorkerPrefab then
+                local npc = WorkerPrefab:Clone()
+                npc.Parent = workspace:FindFirstChild(faction.."Units") or workspace
+                table.insert(st.NPCs, npc)
+                NPCBrain.Init(npc, faction)
+            end
+        end
+    elseif have > want then
+        for i = have, want+1, -1 do
+            local npc = table.remove(st.NPCs)
+            if npc then npc:Destroy() end
+        end
+    end
+end
+
+RunService.Heartbeat:Connect(function()
+    for _, f in ipairs(Config.FACTIONS) do
+        ensureNPCs(f)
+    end
+end)

--- a/src/StarterPlayer/StarterPlayerScripts/UI_AssignPanel.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/UI_AssignPanel.client.lua
@@ -1,0 +1,15 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local UserInputService = game:GetService("UserInputService")
+
+local AssignJob = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("AssignJob")
+
+-- Minimal placeholder: press keys to send job requests
+UserInputService.InputBegan:Connect(function(input, gp)
+    if gp then return end
+    if input.KeyCode == Enum.KeyCode.H then
+        AssignJob:FireServer({type="Haul"})
+    elseif input.KeyCode == Enum.KeyCode.F then
+        AssignJob:FireServer({type="Farm"})
+    end
+end)

--- a/src/StarterPlayer/StarterPlayerScripts/UI_BuildMenu.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/UI_BuildMenu.client.lua
@@ -1,0 +1,28 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local RequestBuild = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("RequestBuild")
+local Config = require(ReplicatedStorage.Modules.Config)
+
+local player = Players.LocalPlayer
+local gui = Instance.new("ScreenGui")
+gui.Name = "BuildMenu"
+local frame = Instance.new("Frame")
+frame.Size = UDim2.new(0,200,0,300)
+frame.Position = UDim2.new(0,10,0,40)
+frame.Parent = gui
+gui.Parent = player:WaitForChild("PlayerGui")
+
+local y = 0
+for name,_ in pairs(Config.BUILD_COSTS) do
+    local button = Instance.new("TextButton")
+    button.Size = UDim2.new(1,0,0,30)
+    button.Position = UDim2.new(0,0,0,y)
+    button.Text = name
+    button.Parent = frame
+    y = y + 30
+    button.MouseButton1Click:Connect(function()
+        local pos = Vector3.new(0,0,0)
+        RequestBuild:FireServer(name, pos)
+    end)
+end

--- a/src/StarterPlayer/StarterPlayerScripts/UI_LobbyBanner.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/UI_LobbyBanner.client.lua
@@ -1,0 +1,21 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local LobbyStatus = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("LobbyStatus")
+
+local player = Players.LocalPlayer
+local gui = Instance.new("ScreenGui")
+gui.Name = "LobbyBanner"
+local label = Instance.new("TextLabel")
+label.Size = UDim2.new(1,0,0,30)
+label.Text = "Waiting for players..."
+label.Parent = gui
+gui.Parent = player:WaitForChild("PlayerGui")
+
+LobbyStatus.OnClientEvent:Connect(function(data)
+    if player.Team and player.Team.Name == "Spectator" then
+        label.Text = "Waiting for an even player count."
+    else
+        label.Text = string.format("Atk:%d Def:%d Total:%d Even:%s", data.attackers, data.defenders, data.total, tostring(data.evenReady))
+    end
+end)


### PR DESCRIPTION
## Summary
- scaffold config, economy, job queue, and NPC brain modules
- add remote events and services for matchmaking, builds, and economy ticks
- stub basic UI scripts for lobby banner, build menu, and job assignment

## Testing
- `luau --version` *(fails: command not found)*
- `rojo build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad427f2ca4832b9b3ed009744f1ab6