### PR TITLE
feat(castle): configurable scale/position/yaw applied to spawner & worldgen

### DIFF
--- a/src/ServerScriptService/PrefabSpawner.server.lua
+++ b/src/ServerScriptService/PrefabSpawner.server.lua
@@ -65,29 +65,43 @@ end
 -- Resolve final placement settings for a given prefab (model) and its rule
 local function resolvePlacement(prefab: Instance, rule)
     -- Attributes override defaults
-    local count  = tonumber(prefab:GetAttribute("Count")) or rule.count or 1
-    local tgtFol = prefab:GetAttribute("TargetFolder") or rule.folder or "Nature"
-    local area   = rule.area or Config.SCATTER_AREA
-    local minS   = tonumber(prefab:GetAttribute("MinScale")) or rule.minScale or 1.0
-    local maxS   = tonumber(prefab:GetAttribute("MaxScale")) or rule.maxScale or 1.0
-    local yawOnly= (prefab:GetAttribute("YawOnly") ~= nil) and (prefab:GetAttribute("YawOnly") == true) or (rule.yawOnly ~= false)
+    local count   = tonumber(prefab:GetAttribute("Count")) or rule.count or 1
+    local tgtFol  = prefab:GetAttribute("TargetFolder") or rule.folder or "Nature"
+    local area    = rule.area or Config.SCATTER_AREA
+    local minS    = tonumber(prefab:GetAttribute("MinScale")) or rule.minScale or 1.0
+    local maxS    = tonumber(prefab:GetAttribute("MaxScale")) or rule.maxScale or 1.0
+    local yawOnly = (prefab:GetAttribute("YawOnly") ~= nil) and (prefab:GetAttribute("YawOnly") == true) or (rule.yawOnly ~= false)
 
-    -- Fixed placement overrides (if X/Y/Z set on the prefab)
-    local hasFixed = (prefab:GetAttribute("X") ~= nil) or (prefab:GetAttribute("Z") ~= nil) or (prefab:GetAttribute("Y") ~= nil)
-    local fx = tonumber(prefab:GetAttribute("X")) or 0
-    local fy = tonumber(prefab:GetAttribute("Y")) or 0
-    local fz = tonumber(prefab:GetAttribute("Z")) or 0
-    local yaw = tonumber(prefab:GetAttribute("Yaw")) or nil -- degrees
+    -- Fixed placement overrides (Attributes > rule.fixedPos)
+    local attrHasFixed = (prefab:GetAttribute("X") ~= nil) or (prefab:GetAttribute("Y") ~= nil) or (prefab:GetAttribute("Z") ~= nil)
+    local fx  = tonumber(prefab:GetAttribute("X"))
+    local fy  = tonumber(prefab:GetAttribute("Y"))
+    local fz  = tonumber(prefab:GetAttribute("Z"))
+    local fay = tonumber(prefab:GetAttribute("Yaw")) -- degrees
+
+    local fixedPos = nil
+    if attrHasFixed then
+        fixedPos = Vector3.new(fx or 0, fy or 0, fz or 0)
+    elseif rule.fixedPos then
+        fixedPos = rule.fixedPos
+    end
+
+    local fixedYaw = nil
+    if fay ~= nil then
+        fixedYaw = fay
+    elseif rule.fixedYaw ~= nil then
+        fixedYaw = rule.fixedYaw
+    end
 
     return {
-        count = count,
+        count        = count,
         targetFolder = tgtFol,
-        area = area,
-        minScale = minS,
-        maxScale = maxS,
-        yawOnly = yawOnly,
-        fixed = hasFixed and Vector3.new(fx, fy, fz) or nil,
-        fixedYaw = yaw, -- degrees
+        area         = area,
+        minScale     = minS,
+        maxScale     = maxS,
+        yawOnly      = yawOnly,
+        fixed        = fixedPos,   -- Vector3 or nil
+        fixedYaw     = fixedYaw,   -- degrees or nil
     }
 end
 
@@ -114,7 +128,7 @@ for _,prefab in ipairs(Models:GetChildren()) do
         end
 
         local yawRad
-        if settings.fixedYaw then
+        if settings.fixedYaw ~= nil then
             yawRad = math.rad(settings.fixedYaw)
         elseif settings.yawOnly ~= false then
             yawRad = math.rad(math.random(0,359))

--- a/src/ServerScriptService/WorldGen.server.lua
+++ b/src/ServerScriptService/WorldGen.server.lua
@@ -8,6 +8,8 @@ World:ClearAllChildren()
 math.randomseed(tick())
 
 local Scatter = require(script.Parent:WaitForChild("_ScatterUtil"))
+local Config  = require(script.Parent["_Config.module"])
+local Spawner = require(script.Parent["_Spawner.util"])
 
 local function mkPart(name, size, cf, color, material, anchored, parent)
     local p = Instance.new("Part")
@@ -90,7 +92,17 @@ local half = wallLen/2 - 6
 tower(-half, -half); tower(half, -half); tower(-half, half); tower(half, half)
 
 -- Keep
-mkPart("Keep", Vector3.new(24, 28, 24), CFrame.new(castleCenter + Vector3.new(0, 14, 0)), Color3.fromRGB(175,175,175), Enum.Material.Concrete, true, Castle)
+local keep = mkPart("Keep", Vector3.new(24, 28, 24), CFrame.new(castleCenter + Vector3.new(0, 14, 0)), Color3.fromRGB(175,175,175), Enum.Material.Concrete, true, Castle)
+
+-- Optional castle prefab override
+local Models = ReplicatedStorage:FindFirstChild("Models")
+local CastlePrefab = Models and Models:FindFirstChild("Castle")
+if CastlePrefab then
+    keep:Destroy()
+    local yawRad = math.rad(Config.CASTLE_YAW or 0)
+    local cf = CFrame.new(Config.CASTLE_POS or Vector3.new(180,0,40)) * CFrame.Angles(0, yawRad, 0)
+    Spawner.CloneAt(CastlePrefab, Castle, cf, Config.CASTLE_SCALE, Config.CASTLE_SCALE)
+end
 
 -- Gate Model with open/close door part (hinge-less slide), plus a ProximityPrompt
 local Gate = Instance.new("Model"); Gate.Name = "Gate"; Gate.Parent = Castle

--- a/src/ServerScriptService/_Config.module.lua
+++ b/src/ServerScriptService/_Config.module.lua
@@ -14,5 +14,10 @@ return {
     AVOID_BANDS = {
         -- { axis = "Z", center = -40, margin = 50 },
     },
+
+    -- === NEW: Castle controls ===
+    CASTLE_SCALE = 1.6,                         -- uniform scale (1.0 = original; try 1.3–2.0)
+    CASTLE_POS   = Vector3.new(180, 0, 40),     -- default castle position
+    CASTLE_YAW   = 0,                           -- degrees (0 keeps current facing)
 }
 

--- a/src/ServerScriptService/_PrefabRules.module.lua
+++ b/src/ServerScriptService/_PrefabRules.module.lua
@@ -7,10 +7,14 @@ local Config = require(script.Parent["_Config.module"])
 local Rules = {
     -- prefix = { folder = "<WorldSubfolder>", count = n, area = {min=V3,max=V3}, minScale=0.95, maxScale=1.1, yawOnly=true }
     Castle = {
-        folder   = "Castle",
-        count    = 1,
-        minScale = 1.0, maxScale = 1.0,
-        yawOnly  = true,
+        folder    = "Castle",
+        count     = 1,
+        minScale  = Config.CASTLE_SCALE,   -- <== scaled from config
+        maxScale  = Config.CASTLE_SCALE,   -- fixed uniform scale
+        yawOnly   = true,
+        -- NEW: support fixed placement via rule if no per-model Attributes are set
+        fixedPos  = Config.CASTLE_POS,     -- Vector3 or nil
+        fixedYaw  = Config.CASTLE_YAW,     -- degrees or nil
     },
     Village = {
         folder   = "Village",
@@ -54,7 +58,7 @@ local Rules = {
 }
 
 -- Fallback when no prefix matches: drop into Nature, count=1
-Rules.__default = {
+Rules.__default = Rules.__default or {
     folder   = "Nature",
     count    = 1,
     area     = Config.SCATTER_AREA,


### PR DESCRIPTION
## Summary
- Adds _Config keys `CASTLE_SCALE`, `CASTLE_POS`, `CASTLE_YAW`
- PrefabSpawner honors per-rule fixedPos/fixedYaw when no per-model Attributes are set
- WorldGen uses Config when spawning Castle prefab
- Default scale to 1.6x (can be tuned without code changes)

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aece774190832b975178181f26f0bf